### PR TITLE
Session auth implementation

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -2,7 +2,7 @@ name: Dependency Audit
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
             cache_dependency_path: frontend/package-lock.json
             install_script_allowlist: |
               {
-                "esbuild@0.25.3": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
+                "esbuild@0.25.12": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
                 "fsevents@2.3.3": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
               }
           - project: frontend-docs-site

--- a/backend/.sqlx/query-e0f41147ec6888ccade24a344ffc3d3f6c155b3bf7fd0b88f5823f3848dfa32e.json
+++ b/backend/.sqlx/query-e0f41147ec6888ccade24a344ffc3d3f6c155b3bf7fd0b88f5823f3848dfa32e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_sessions WHERE expires_at < now()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "e0f41147ec6888ccade24a344ffc3d3f6c155b3bf7fd0b88f5823f3848dfa32e"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1322,7 +1322,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dsentr-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsentr-backend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"  # 👈 reverting to "2021" for now - most crates aren't tested on 2024 yet
 
 [dependencies]
@@ -20,6 +20,7 @@ sqlx = { version = "0.8", features = [ "runtime-tokio-rustls", "uuid", "postgres
 dotenv = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+once_cell = "1.21.3"
 boa_engine = "0.17"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }  # enable structured logging support
@@ -59,7 +60,6 @@ sentry-tracing = "0.45.0"
 [dev-dependencies]
 hyper = "1"
 mockall = "0.13.1"
-once_cell = "1.21.3"
 httpmock = "0.7"
 
 [features]

--- a/backend/migrations/202511072_2_create_user_sessions.sql
+++ b/backend/migrations/202511072_2_create_user_sessions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE user_sessions (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  data JSONB NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX user_sessions_user_id_idx ON user_sessions USING BTREE (user_id);
+CREATE INDEX user_sessions_expires_at_idx ON user_sessions USING BTREE (expires_at);
+
+-- Rollback:
+--   DROP INDEX IF EXISTS user_sessions_expires_at_idx;
+--   DROP INDEX IF EXISTS user_sessions_user_id_idx;
+--   DROP TABLE IF EXISTS user_sessions;
+

--- a/backend/src/engine/actions/email.rs
+++ b/backend/src/engine/actions/email.rs
@@ -952,7 +952,10 @@ mod tests {
     use crate::services::oauth::google::mock_google_oauth::MockGoogleOAuth;
     use crate::services::oauth::workspace_service::WorkspaceOAuthService;
     use crate::services::smtp_mailer::{MailError, Mailer, MockMailer, SmtpConfig, TlsMode};
-    use crate::{state::AppState, utils::jwt::JwtKeys};
+    use crate::{
+        state::{test_pg_pool, AppState},
+        utils::jwt::JwtKeys,
+    };
     use async_trait::async_trait;
     use axum::body::{Body, Bytes};
     use axum::extract::State;
@@ -1054,6 +1057,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer,
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/engine/actions/google.rs
+++ b/backend/src/engine/actions/google.rs
@@ -7,6 +7,8 @@ use crate::models::oauth_token::ConnectedOAuthProvider;
 use crate::models::workflow_run::WorkflowRun;
 use crate::services::oauth::account_service::{is_revocation_signal, OAuthAccountError};
 use crate::services::oauth::workspace_service::WorkspaceOAuthError;
+#[cfg(test)]
+use crate::state::test_pg_pool;
 use crate::state::AppState;
 use serde_json::{json, Map, Value};
 use tracing::warn;
@@ -831,6 +833,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()) as Arc<dyn Mailer>,
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/engine/actions/messaging.rs
+++ b/backend/src/engine/actions/messaging.rs
@@ -1681,7 +1681,7 @@ mod tests {
             },
             smtp_mailer::MockMailer,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::{encryption::encrypt_secret, jwt::JwtKeys},
     };
     use sqlx::Error as SqlxError;
@@ -2038,6 +2038,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/engine/executor.rs
+++ b/backend/src/engine/executor.rs
@@ -677,7 +677,7 @@ mod tests {
     use crate::services::oauth::workspace_service::WorkspaceOAuthService;
     use crate::services::smtp_mailer::MockMailer;
     use crate::services::stripe::MockStripeService;
-    use crate::state::AppState;
+    use crate::state::{test_pg_pool, AppState};
     use crate::utils::jwt::JwtKeys;
     use reqwest::Client;
     use serde_json::json;
@@ -732,6 +732,7 @@ mod tests {
             workflow_repo,
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/routes/auth/forgot_password.rs
+++ b/backend/src/routes/auth/forgot_password.rs
@@ -80,7 +80,7 @@ mod tests {
             },
             smtp_mailer::MockMailer,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     };
     use reqwest::Client;
@@ -328,6 +328,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer,
             google_oauth,
             github_oauth,
@@ -453,6 +454,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer,
             google_oauth,
             github_oauth,

--- a/backend/src/routes/auth/google_login.rs
+++ b/backend/src/routes/auth/google_login.rs
@@ -7,7 +7,7 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use reqwest::Url;
 
-use crate::utils::jwt::create_jwt;
+use crate::session;
 use crate::AppState;
 use crate::{
     models::user::OauthProvider, responses::JsonResponse, utils::csrf::generate_csrf_token,
@@ -16,6 +16,7 @@ use crate::{
     routes::auth::claims::{Claims, TokenUse},
     services::oauth::google::errors::GoogleAuthError,
 };
+use tracing::{error, info};
 
 pub async fn google_login(
     State(app_state): State<AppState>,
@@ -247,27 +248,11 @@ pub async fn google_callback(
             .into_response();
         }
     };
-    let access_duration = chrono::Duration::minutes(45);
-    let refresh_duration = chrono::Duration::days(30);
-
-    let access_claims = Claims {
+    let session_ttl_hours = 24 * 30;
+    let claims = Claims {
         id: user.id.to_string(),
         role: user.role,
-        exp: (chrono::Utc::now() + access_duration).timestamp() as usize,
-        email: email.to_string(),
-        first_name: first_name.clone(),
-        last_name: last_name.clone(),
-        plan: None,
-        company_name: None,
-        iss: String::new(),
-        aud: String::new(),
-        token_use: TokenUse::Access,
-    };
-
-    let refresh_claims = Claims {
-        id: user.id.to_string(),
-        role: user.role,
-        exp: (chrono::Utc::now() + refresh_duration).timestamp() as usize,
+        exp: (chrono::Utc::now() + chrono::Duration::hours(session_ttl_hours)).timestamp() as usize,
         email: email.to_string(),
         first_name,
         last_name,
@@ -275,54 +260,48 @@ pub async fn google_callback(
         company_name: None,
         iss: String::new(),
         aud: String::new(),
-        token_use: TokenUse::Refresh,
+        token_use: TokenUse::Access,
     };
 
-    let jwt = match create_jwt(
-        access_claims,
-        app_state.jwt_keys.as_ref(),
-        &app_state.config.jwt_issuer,
-        &app_state.config.jwt_audience,
-    ) {
-        Ok(token) => token,
-        Err(_) => {
+    let session_value = match serde_json::to_value(&claims) {
+        Ok(val) => val,
+        Err(err) => {
+            error!(?err, user_id=%user.id, "failed to serialize claims for Google session");
             return JsonResponse::redirect_to_login_with_error(
                 &GoogleAuthError::JwtCreationFailed.to_string(),
             )
-            .into_response()
+            .into_response();
         }
     };
 
-    let refresh_jwt = match create_jwt(
-        refresh_claims,
-        app_state.jwt_keys.as_ref(),
-        &app_state.config.jwt_issuer,
-        &app_state.config.jwt_audience,
-    ) {
-        Ok(token) => token,
-        Err(_) => {
+    let (session_id, _) = match session::create_session(
+        app_state.db_pool.as_ref(),
+        user.id,
+        session_value,
+        session_ttl_hours,
+    )
+    .await
+    {
+        Ok((session_id, session)) => {
+            info!(%session_id, user_id=%user.id, "google session created");
+            (session_id, session)
+        }
+        Err(err) => {
+            error!(?err, user_id=%user.id, "failed to create session for Google login");
             return JsonResponse::redirect_to_login_with_error(
                 &GoogleAuthError::JwtCreationFailed.to_string(),
             )
-            .into_response()
+            .into_response();
         }
     };
 
     let secure_cookie = app_state.config.auth_cookie_secure;
-    let auth_cookie = Cookie::build(("auth_token", jwt))
+    let auth_cookie = Cookie::build(("dsentr_session", session_id.to_string()))
         .http_only(true)
         .secure(secure_cookie)
         .same_site(SameSite::Lax)
         .path("/")
-        .max_age(time::Duration::seconds(access_duration.num_seconds()))
-        .build();
-
-    let refresh_cookie = Cookie::build(("auth_refresh_token", refresh_jwt))
-        .http_only(true)
-        .secure(secure_cookie)
-        .same_site(SameSite::Lax)
-        .path("/")
-        .max_age(time::Duration::seconds(refresh_duration.num_seconds()))
+        .max_age(time::Duration::hours(session_ttl_hours))
         .build();
     let frontend_url =
         std::env::var("FRONTEND_ORIGIN").unwrap_or_else(|_| "https://localhost:5173".to_string());
@@ -340,7 +319,6 @@ pub async fn google_callback(
 
     let jar = CookieJar::new()
         .add(auth_cookie)
-        .add(refresh_cookie)
         .add(clear_state_cookie)
         .add(clear_tos_cookie);
     (jar, Redirect::to(&format!("{}/dashboard", frontend_url))).into_response()
@@ -380,7 +358,7 @@ mod tests {
             },
             smtp_mailer::MockMailer,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     }; // for `.oneshot()`
     use reqwest::Client;
@@ -432,6 +410,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -489,6 +468,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer,
             google_oauth,
             github_oauth,
@@ -568,6 +548,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(FailingGoogleOAuth),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/routes/auth/reset_password.rs
+++ b/backend/src/routes/auth/reset_password.rs
@@ -102,7 +102,7 @@ mod tests {
             account_service::OAuthAccountService, github::mock_github_oauth::MockGitHubOAuth,
             google::mock_google_oauth::MockGoogleOAuth, workspace_service::WorkspaceOAuthService,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     };
     use reqwest::Client;
@@ -354,6 +354,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(crate::services::smtp_mailer::MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/routes/auth/signup.rs
+++ b/backend/src/routes/auth/signup.rs
@@ -249,7 +249,7 @@ mod tests {
             },
             smtp_mailer::{Mailer, MockMailer},
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     };
     use reqwest::Client;
@@ -812,6 +812,7 @@ mod tests {
                 workflow_repo: Arc::new(NoopWorkflowRepository),
                 workspace_repo,
                 workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+                db_pool: test_pg_pool(),
                 mailer: Arc::new(mailer),
                 github_oauth: Arc::new(MockGitHubOAuth::default()),
                 google_oauth: Arc::new(MockGoogleOAuth::default()),

--- a/backend/src/routes/auth/verify.rs
+++ b/backend/src/routes/auth/verify.rs
@@ -64,7 +64,7 @@ mod tests {
             },
             smtp_mailer::MockMailer,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     };
     use reqwest::Client;
@@ -113,6 +113,7 @@ mod tests {
                 workflow_repo: Arc::new(NoopWorkflowRepository),
                 workspace_repo: Arc::new(NoopWorkspaceRepository),
                 workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+                db_pool: test_pg_pool(),
                 mailer: Arc::new(MockMailer::default()),
                 github_oauth: Arc::new(MockGitHubOAuth::default()),
                 google_oauth: Arc::new(MockGoogleOAuth::default()),

--- a/backend/src/routes/early_access.rs
+++ b/backend/src/routes/early_access.rs
@@ -51,7 +51,7 @@ mod tests {
             },
             smtp_mailer::MockMailer,
         },
-        state::AppState,
+        state::{test_pg_pool, AppState},
         utils::jwt::JwtKeys,
     };
     use reqwest::Client;
@@ -100,6 +100,7 @@ mod tests {
                 workflow_repo: Arc::new(NoopWorkflowRepository),
                 workspace_repo: Arc::new(NoopWorkspaceRepository),
                 workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+                db_pool: test_pg_pool(),
                 mailer: Arc::new(MockMailer::default()),
                 github_oauth: Arc::new(MockGitHubOAuth::default()),
                 google_oauth: Arc::new(MockGoogleOAuth::default()),

--- a/backend/src/routes/microsoft.rs
+++ b/backend/src/routes/microsoft.rs
@@ -388,7 +388,7 @@ mod tests {
         },
         smtp_mailer::MockMailer,
     };
-    use crate::state::AppState;
+    use crate::state::{test_pg_pool, AppState};
     use crate::utils::{encryption::encrypt_secret, jwt::JwtKeys};
 
     #[derive(Clone)]
@@ -606,6 +606,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/routes/oauth/tests.rs
+++ b/backend/src/routes/oauth/tests.rs
@@ -32,6 +32,7 @@ use crate::services::{
     },
     smtp_mailer::MockMailer,
 };
+use crate::state::test_pg_pool;
 use crate::state::AppState;
 use crate::utils::encryption::encrypt_secret;
 use crate::utils::jwt::JwtKeys;
@@ -91,6 +92,7 @@ fn stub_state(config: Arc<Config>) -> AppState {
         workflow_repo: Arc::new(NoopWorkflowRepository),
         workspace_repo: Arc::new(NoopWorkspaceRepository),
         workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+        db_pool: test_pg_pool(),
         mailer: Arc::new(MockMailer::default()),
         google_oauth: Arc::new(MockGoogleOAuth::default()),
         github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/routes/stripe.rs
+++ b/backend/src/routes/stripe.rs
@@ -491,7 +491,7 @@ mod tests {
     };
     use crate::services::smtp_mailer::MockMailer;
     use crate::services::stripe::MockStripeService;
-    use crate::state::AppState;
+    use crate::state::{test_pg_pool, AppState};
     use crate::utils::jwt::JwtKeys;
     use axum::extract::State as AxumState;
     use axum::http::{HeaderMap, HeaderValue};
@@ -825,6 +825,7 @@ mod tests {
             workspace_connection_repo: Arc::new(
                 crate::db::workspace_connection_repository::NoopWorkspaceConnectionRepository,
             ),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(
                 crate::services::oauth::google::mock_google_oauth::MockGoogleOAuth::default(),
@@ -935,6 +936,7 @@ mod tests {
             workspace_connection_repo: Arc::new(
                 crate::db::workspace_connection_repository::NoopWorkspaceConnectionRepository,
             ),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(
                 crate::services::oauth::google::mock_google_oauth::MockGoogleOAuth::default(),
@@ -1049,6 +1051,7 @@ mod tests {
             workspace_connection_repo: Arc::new(
                 crate::db::workspace_connection_repository::NoopWorkspaceConnectionRepository,
             ),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(
                 crate::services::oauth::google::mock_google_oauth::MockGoogleOAuth::default(),

--- a/backend/src/routes/workspaces.rs
+++ b/backend/src/routes/workspaces.rs
@@ -1936,7 +1936,7 @@ mod tests {
         },
         smtp_mailer::{MailError, Mailer, MockMailer, SmtpConfig},
     };
-    use crate::state::AppState;
+    use crate::state::{test_pg_pool, AppState};
     use crate::utils::{encryption::encrypt_secret, jwt::JwtKeys};
     use async_trait::async_trait;
     use axum::{
@@ -2945,6 +2945,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo,
             workspace_connection_repo,
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -2965,6 +2966,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: repo,
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(NoopMailer),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -2989,6 +2991,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: repo,
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer,
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -3645,7 +3648,7 @@ mod tests {
         use crate::db::mock_db::NoopWorkflowRepository;
         use crate::db::workspace_connection_repository::NoopWorkspaceConnectionRepository;
         use crate::services::stripe::MockStripeService as StripeMock;
-        use crate::state::AppState;
+        use crate::state::{test_pg_pool, AppState};
 
         let user_id = Uuid::new_v4();
         let now = OffsetDateTime::now_utc();
@@ -3677,6 +3680,7 @@ mod tests {
             workflow_repo: Arc::new(NoopWorkflowRepository),
             workspace_repo: Arc::new(RecordingWorkspaceRepo::default()),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(NoopMailer),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -1,0 +1,426 @@
+use chrono::{DateTime, Duration, Utc};
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use serde_json::Value;
+use sqlx::{PgPool, Row};
+#[cfg(not(test))]
+use tracing::{debug, warn};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::utils::schedule::{offset_to_utc, utc_to_offset};
+
+#[cfg(test)]
+use std::sync::OnceLock;
+#[derive(Clone, Debug)]
+pub struct SessionData {
+    pub user_id: Uuid,
+    pub data: Value,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+pub static SESSION_CACHE: Lazy<DashMap<Uuid, SessionData>> = Lazy::new(DashMap::new);
+
+#[cfg(test)]
+static TEST_SESSION_STORE: OnceLock<DashMap<Uuid, SessionData>> = OnceLock::new();
+
+#[cfg(test)]
+fn test_session_store() -> &'static DashMap<Uuid, SessionData> {
+    TEST_SESSION_STORE.get_or_init(DashMap::new)
+}
+
+#[cfg(test)]
+fn build_in_memory_session(user_id: Uuid, data: Value, ttl_hours: i64) -> SessionData {
+    let now = Utc::now();
+    SessionData {
+        user_id,
+        data,
+        created_at: now,
+        expires_at: now + Duration::hours(ttl_hours.max(1)),
+    }
+}
+
+#[cfg(test)]
+fn cache_test_session(session_id: Uuid, session: SessionData) -> SessionData {
+    test_session_store().insert(session_id, session.clone());
+    SESSION_CACHE.insert(session_id, session.clone());
+    session
+}
+
+#[cfg(test)]
+fn get_in_memory_session(session_id: Uuid) -> Option<SessionData> {
+    if let Some(cached) = SESSION_CACHE.get(&session_id) {
+        if cached.expires_at > Utc::now() {
+            return Some(cached.clone());
+        }
+
+        drop(cached);
+        SESSION_CACHE.remove(&session_id);
+    }
+
+    let store = test_session_store();
+    if let Some(entry) = store.get(&session_id) {
+        if entry.expires_at > Utc::now() {
+            let session = entry.clone();
+            drop(entry);
+            SESSION_CACHE.insert(session_id, session.clone());
+            Some(session)
+        } else {
+            drop(entry);
+            store.remove(&session_id);
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+fn delete_in_memory_session(session_id: Uuid) -> bool {
+    let mut removed = SESSION_CACHE.remove(&session_id).is_some();
+    if let Some(store) = TEST_SESSION_STORE.get() {
+        removed |= store.remove(&session_id).is_some();
+    }
+    removed
+}
+
+#[cfg(test)]
+pub fn reset_test_sessions() {
+    if let Some(store) = TEST_SESSION_STORE.get() {
+        store.clear();
+    }
+    SESSION_CACHE.clear();
+}
+
+#[cfg(test)]
+pub fn insert_test_session(session_id: Uuid, session: SessionData) {
+    cache_test_session(session_id, session);
+}
+
+pub async fn create_session(
+    pool: &PgPool,
+    user_id: Uuid,
+    data: Value,
+    ttl_hours: i64,
+) -> Result<(Uuid, SessionData), sqlx::Error> {
+    #[cfg(test)]
+    {
+        let _ = pool;
+        let session_id = Uuid::new_v4();
+        let session = build_in_memory_session(user_id, data, ttl_hours);
+        let session = cache_test_session(session_id, session);
+        Ok((session_id, session))
+    }
+
+    #[cfg(not(test))]
+    {
+        let session_id = Uuid::new_v4();
+        persist_session(pool, session_id, user_id, data, ttl_hours)
+            .await
+            .map(|session| (session_id, session))
+    }
+}
+
+pub async fn get_session(
+    pool: &PgPool,
+    session_id: Uuid,
+) -> Result<Option<SessionData>, sqlx::Error> {
+    #[cfg(test)]
+    {
+        let _ = pool;
+        Ok(get_in_memory_session(session_id))
+    }
+
+    #[cfg(not(test))]
+    {
+        if let Some(cached) = SESSION_CACHE.get(&session_id) {
+            if cached.expires_at > Utc::now() {
+                debug!(%session_id, "Session cache hit");
+                return Ok(Some(cached.clone()));
+            }
+
+            debug!(%session_id, "Cached session expired, evicting");
+            SESSION_CACHE.remove(&session_id);
+        } else {
+            debug!(%session_id, "Session cache miss");
+        }
+
+        match sqlx::query(
+            r#"
+            SELECT user_id, data, expires_at, created_at
+            FROM user_sessions
+            WHERE id = $1
+            "#,
+        )
+        .bind(session_id)
+        .fetch_optional(pool)
+        .await
+        {
+            Ok(Some(record)) => {
+                let expires_at_offset: time::OffsetDateTime = match record.try_get("expires_at") {
+                    Ok(value) => value,
+                    Err(error) => {
+                        error!(?error, %session_id, "Failed to read expires_at from session row");
+                        return Err(error);
+                    }
+                };
+                let expires_at = match offset_to_utc(expires_at_offset) {
+                    Some(value) => value,
+                    None => {
+                        error!(%session_id, "Failed to convert stored expiration timestamp");
+                        return Err(sqlx::Error::Protocol(
+                            "failed to convert session expiration from Postgres".to_string(),
+                        ));
+                    }
+                };
+
+                if expires_at <= Utc::now() {
+                    warn!(%session_id, "Session expired in storage, removing");
+                    if let Err(error) = delete_session(pool, session_id).await {
+                        error!(%session_id, error = ?error, "Failed to purge expired session");
+                    }
+                    return Ok(None);
+                }
+
+                let created_at_offset: time::OffsetDateTime = match record.try_get("created_at") {
+                    Ok(value) => value,
+                    Err(error) => {
+                        error!(?error, %session_id, "Failed to read created_at from session row");
+                        return Err(error);
+                    }
+                };
+                let created_at = match offset_to_utc(created_at_offset) {
+                    Some(value) => value,
+                    None => {
+                        error!(%session_id, "Failed to convert stored created_at timestamp");
+                        return Err(sqlx::Error::Protocol(
+                            "failed to convert session created_at from Postgres".to_string(),
+                        ));
+                    }
+                };
+
+                let user_id: Uuid = match record.try_get("user_id") {
+                    Ok(value) => value,
+                    Err(error) => {
+                        error!(?error, %session_id, "Failed to read user_id from session row");
+                        return Err(error);
+                    }
+                };
+
+                let data: Value = match record.try_get("data") {
+                    Ok(value) => value,
+                    Err(error) => {
+                        error!(?error, %session_id, "Failed to read session payload");
+                        return Err(error);
+                    }
+                };
+
+                let session = SessionData {
+                    user_id,
+                    data,
+                    expires_at,
+                    created_at,
+                };
+                SESSION_CACHE.insert(session_id, session.clone());
+                debug!(%session_id, "Session cache refreshed from Postgres");
+
+                Ok(Some(session))
+            }
+            Ok(None) => Ok(None),
+            Err(error) => {
+                error!(%session_id, error = ?error, "Failed to load session from Postgres");
+                Err(error)
+            }
+        }
+    }
+}
+
+pub async fn upsert_session(
+    pool: &PgPool,
+    session_id: Uuid,
+    user_id: Uuid,
+    data: Value,
+    ttl_hours: i64,
+) -> Result<SessionData, sqlx::Error> {
+    #[cfg(test)]
+    {
+        let _ = pool;
+        let session = build_in_memory_session(user_id, data, ttl_hours);
+        let session = cache_test_session(session_id, session);
+        Ok(session)
+    }
+
+    #[cfg(not(test))]
+    {
+        persist_session(pool, session_id, user_id, data, ttl_hours).await
+    }
+}
+
+pub async fn delete_session(pool: &PgPool, session_id: Uuid) -> Result<bool, sqlx::Error> {
+    #[cfg(test)]
+    {
+        let _ = pool;
+        Ok(delete_in_memory_session(session_id))
+    }
+
+    #[cfg(not(test))]
+    {
+        let removed = SESSION_CACHE.remove(&session_id).is_some();
+
+        match sqlx::query("DELETE FROM user_sessions WHERE id = $1")
+            .bind(session_id)
+            .execute(pool)
+            .await
+        {
+            Ok(result) => {
+                let deleted = result.rows_affected() > 0;
+
+                if deleted {
+                    info!(%session_id, "Deleted session from cache and Postgres");
+                } else if removed {
+                    warn!(%session_id, "Session missing from Postgres but removed from cache");
+                } else {
+                    debug!(%session_id, "No session found to delete");
+                }
+
+                Ok(deleted)
+            }
+            Err(error) => {
+                error!(%session_id, error = ?error, "Failed to delete session");
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg_attr(test, allow(dead_code))]
+async fn persist_session(
+    pool: &PgPool,
+    session_id: Uuid,
+    user_id: Uuid,
+    data: Value,
+    ttl_hours: i64,
+) -> Result<SessionData, sqlx::Error> {
+    let expires_at = Utc::now() + Duration::hours(ttl_hours);
+    let expires_at_offset = match utc_to_offset(expires_at) {
+        Some(value) => value,
+        None => {
+            error!(
+                %session_id,
+                %user_id,
+                "Failed to convert expiration timestamp to OffsetDateTime"
+            );
+            return Err(sqlx::Error::Protocol(
+                "failed to convert expiration timestamp to OffsetDateTime".to_string(),
+            ));
+        }
+    };
+
+    match sqlx::query(
+        r#"
+        INSERT INTO user_sessions (id, user_id, data, expires_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (id) DO UPDATE
+        SET user_id = EXCLUDED.user_id,
+            data = EXCLUDED.data,
+            expires_at = EXCLUDED.expires_at
+        RETURNING user_id, data, expires_at, created_at
+        "#,
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .bind(data.clone())
+    .bind(expires_at_offset)
+    .fetch_one(pool)
+    .await
+    {
+        Ok(record) => {
+            let expires_at_offset: time::OffsetDateTime = match record.try_get("expires_at") {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(
+                        %session_id,
+                        %user_id,
+                        ?error,
+                        "Failed to read expires_at from persisted session"
+                    );
+                    return Err(error);
+                }
+            };
+            let expires_at = match offset_to_utc(expires_at_offset) {
+                Some(value) => value,
+                None => {
+                    error!(
+                        %session_id,
+                        %user_id,
+                        "Failed to convert stored expiration timestamp"
+                    );
+                    return Err(sqlx::Error::Protocol(
+                        "failed to convert session expiration from Postgres".to_string(),
+                    ));
+                }
+            };
+            let created_at_offset: time::OffsetDateTime = match record.try_get("created_at") {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(
+                        %session_id,
+                        %user_id,
+                        ?error,
+                        "Failed to read created_at from persisted session"
+                    );
+                    return Err(error);
+                }
+            };
+            let created_at = match offset_to_utc(created_at_offset) {
+                Some(value) => value,
+                None => {
+                    error!(%session_id, %user_id, "Failed to convert stored created_at timestamp");
+                    return Err(sqlx::Error::Protocol(
+                        "failed to convert session created_at from Postgres".to_string(),
+                    ));
+                }
+            };
+            let db_user_id: Uuid = match record.try_get("user_id") {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(
+                        %session_id,
+                        %user_id,
+                        ?error,
+                        "Failed to read user_id from persisted session"
+                    );
+                    return Err(error);
+                }
+            };
+            let db_data: Value = match record.try_get("data") {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(
+                        %session_id,
+                        %user_id,
+                        ?error,
+                        "Failed to read session payload from persisted session"
+                    );
+                    return Err(error);
+                }
+            };
+            let session = SessionData {
+                user_id: db_user_id,
+                data: db_data,
+                expires_at,
+                created_at,
+            };
+
+            SESSION_CACHE.insert(session_id, session.clone());
+            info!(%session_id, %user_id, "Persisted session and cached value");
+
+            Ok(session)
+        }
+        Err(error) => {
+            error!(%session_id, %user_id, error = ?error, "Failed to persist session");
+            Err(error)
+        }
+    }
+}

--- a/backend/src/worker/mod.rs
+++ b/backend/src/worker/mod.rs
@@ -360,7 +360,7 @@ mod tests {
     use crate::services::oauth::google::mock_google_oauth::MockGoogleOAuth;
     use crate::services::oauth::workspace_service::WorkspaceOAuthService;
     use crate::services::smtp_mailer::MockMailer;
-    use crate::state::AppState;
+    use crate::state::{test_pg_pool, AppState};
     use mockall::predicate;
     use reqwest::Client;
     use serde_json::json;
@@ -445,6 +445,7 @@ mod tests {
             workflow_repo,
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -670,6 +671,7 @@ mod tests {
             workflow_repo,
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),
@@ -865,6 +867,7 @@ mod tests {
             workflow_repo,
             workspace_repo: Arc::new(NoopWorkspaceRepository),
             workspace_connection_repo: Arc::new(NoopWorkspaceConnectionRepository),
+            db_pool: test_pg_pool(),
             mailer: Arc::new(MockMailer::default()),
             google_oauth: Arc::new(MockGoogleOAuth::default()),
             github_oauth: Arc::new(MockGitHubOAuth::default()),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsentr-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,8 +12,8 @@
     "test:no-cov": "vitest run",
     "test": "vitest run",
     "dev:app": "vite",
-    "dev:api": "cargo run",
-    "dev:api:watch": "cargo watch -x run"
+    "dev:api": "cd ../backend && cargo run",
+    "dev:api:watch": "cd ../backend && cargo watch -x run"
   },
   "dependencies": {
     "@stripe/stripe-js": "^4.8.0",


### PR DESCRIPTION
Still left to do:
I. AppState and startup wiring lack a PgPool reference, session middleware, or cleanup task
1. Extend `AppState` (`backend/src/state.rs`) with `pub db_pool: Arc<PgPool>` (or similar) so handlers/middleware can reach the raw pool; update all constructors in production and tests (use `PgPoolOptions::new().connect_lazy` for mocks) and keep `JwtKeyProvider` impl working.
2. In `main.rs`, clone the existing `pg_pool` into the new `AppState` field and pass an `Arc<PgPool>` into any components that need it.
3. Implement an Axum middleware (e.g. `require_session` inside `routes/auth/session.rs` or a new `session::layer`) that:

   * Pulls the session ID from `Authorization: Bearer <uuid>` or the `dsentr_session` cookie.
   * Calls `session::get_session(&state.db_pool, &session_id)` and, on success, stores `Extension<SessionData>` on the request; on failure, returns `JsonResponse::unauthorized` with a 401 and logs via `tracing`.
4. Apply this middleware with state (`axum::middleware::from_fn_with_state`) to every route stack that currently expects authentication (e.g. `/api/auth` safe routes, account, workflow, etc.) before handlers run.
5. Spawn a background Tokio task during startup that once an hour deletes expired rows with `DELETE FROM user_sessions WHERE expires_at < now()` and purges stale entries from `SESSION_CACHE`, logging counts; add a brief comment describing the expiration policy.

II. Auth handlers still mint/clear JWT cookies instead of using the new session lifecycle
1. Refactor `routes/auth/session.rs` so `AuthSession` reads the `Extension<SessionData>` inserted by the middleware, deserializes `session.data` into `Claims`, and keeps tests passing (add new tests that cover header/cookie extraction and expired sessions).
2. In `handle_login`, replace JWT creation with a call to `session::create_session(&state.db_pool, user.id, serde_json::to_value(&claims_or_user)?, ttl_hours)`:

   * Decide TTL hours based on `remember` flag.
   * Emit `tracing` logs for creation success/failure.
   * Return a `dsentr_session` cookie (`HttpOnly; Secure flag from config; Path=/; Max-Age` from TTL) and ensure the JSON response stays the same.
3. Rework `handle_refresh` to look up the existing session ID (cookie/header), extend its expiration (update `expires_at` in DB + cache), and issue a refreshed cookie rather than minting new JWTs; drop usage of `auth_refresh_token`.
4. Modify `handle_me` (and any other handlers that accept `AuthSession`) to rely on the claims coming from `SessionData`, ensuring user IDs are derived from the stored session payload.
5. Update `handle_logout` to read the session ID, call `session::delete_session`, clear the `dsentr_session` cookie, and log the outcome; adjust associated tests to assert the new cookie name and DB call expectations.
6. Refresh or add integration/unit tests (login, refresh, logout, session extractor) so they pass with the new session workflow, and remove/adjust any JWT-specific assertions.