### PR TITLE
Make workspace promotion payload require explicit personal token ID

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -45,7 +45,6 @@ pub struct OAuthSettings {
     pub slack: OAuthProviderConfig,
     pub asana: OAuthProviderConfig,
     pub token_encryption_key: Vec<u8>,
-    pub require_connection_id: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -157,14 +156,6 @@ impl Config {
                 source,
             })?;
 
-        let require_connection_id = env::var("OAUTH_REQUIRE_CONNECTION_ID")
-            .ok()
-            .map(|value| {
-                let normalized = value.to_ascii_lowercase();
-                matches!(normalized.as_str(), "1" | "true" | "yes")
-            })
-            .unwrap_or(false);
-
         let stripe = StripeSettings {
             client_id: require_env("STRIPE_CLIENT_ID")?,
             secret_key: require_env("STRIPE_SECRET_KEY")?,
@@ -203,7 +194,6 @@ impl Config {
                 slack,
                 asana,
                 token_encryption_key,
-                require_connection_id,
             },
             api_secrets_encryption_key,
             stripe,

--- a/backend/src/engine/actions/email.rs
+++ b/backend/src/engine/actions/email.rs
@@ -1041,7 +1041,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/engine/executor.rs
+++ b/backend/src/engine/executor.rs
@@ -1052,7 +1052,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/asana.rs
+++ b/backend/src/routes/asana.rs
@@ -631,12 +631,10 @@ async fn ensure_asana_token(
                 .await
                 .map(|token| (token, Some(connection_id)))
         }
-        RequestedScope::Personal => state
-            .oauth_accounts
-            .ensure_valid_access_token(user_id, ConnectedOAuthProvider::Asana)
-            .await
-            .map(|token| (token.access_token, None))
-            .map_err(map_oauth_error),
+        RequestedScope::Personal => Err(JsonResponse::bad_request(
+            "Personal scope requires an explicit OAuth connection",
+        )
+        .into_response()),
     }
 }
 

--- a/backend/src/routes/auth/forgot_password.rs
+++ b/backend/src/routes/auth/forgot_password.rs
@@ -117,7 +117,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/github_login.rs
+++ b/backend/src/routes/auth/github_login.rs
@@ -358,7 +358,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/google_login.rs
+++ b/backend/src/routes/auth/google_login.rs
@@ -395,7 +395,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/login.rs
+++ b/backend/src/routes/auth/login.rs
@@ -467,7 +467,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/logout.rs
+++ b/backend/src/routes/auth/logout.rs
@@ -114,7 +114,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/refresh.rs
+++ b/backend/src/routes/auth/refresh.rs
@@ -163,7 +163,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/reset_password.rs
+++ b/backend/src/routes/auth/reset_password.rs
@@ -139,7 +139,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/session.rs
+++ b/backend/src/routes/auth/session.rs
@@ -169,7 +169,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/signup.rs
+++ b/backend/src/routes/auth/signup.rs
@@ -298,7 +298,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/auth/verify.rs
+++ b/backend/src/routes/auth/verify.rs
@@ -101,7 +101,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/early_access.rs
+++ b/backend/src/routes/early_access.rs
@@ -88,7 +88,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/issues.rs
+++ b/backend/src/routes/issues.rs
@@ -551,7 +551,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/oauth/AGENTS.md
+++ b/backend/src/routes/oauth/AGENTS.md
@@ -29,5 +29,5 @@
 - OAuth route test repositories stub `stripe_overage_item_id` accessors so the expanded workspace repository trait for metered billing compiles in the OAuth harness.
 - Added Asana provider parsing, state-cookie wiring, and start/callback handlers so users can connect Asana accounts through the OAuth flow alongside Google, Microsoft, and Slack.
 - Added provider-scoped connection listings and connection-id lookup endpoints so the frontend can target specific personal or workspace OAuth records and receive connection identifiers in responses.
-- Refresh, revoke, and disconnect handlers now accept optional `connection_id` parameters (query or body) and return the targeted connection id while preserving legacy provider-based behavior for older clients.
+- Refresh and disconnect handlers now require an explicit `connection_id` and return 400 for provider-only requests, removing legacy fallbacks and validating missing-id cases even when matching tokens exist.
 - Refresh responses now serialize field names in `camelCase` (e.g., `requiresReconnect`, `connectionId`) to keep the JSON API stable for existing clients and tests.

--- a/backend/src/routes/oauth/prelude.rs
+++ b/backend/src/routes/oauth/prelude.rs
@@ -7,7 +7,7 @@ pub(crate) use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 pub(crate) use reqwest::Url;
 pub(crate) use serde::{Deserialize, Serialize};
 pub(crate) use time::{Duration, OffsetDateTime};
-pub(crate) use tracing::{error, warn};
+pub(crate) use tracing::error;
 pub(crate) use urlencoding::encode;
 pub(crate) use uuid::Uuid;
 

--- a/backend/src/routes/slack.rs
+++ b/backend/src/routes/slack.rs
@@ -95,14 +95,12 @@ pub async fn list_channels(
                 Err(resp) => return resp,
             }
         }
-        RequestedScope::Personal => match state
-            .oauth_accounts
-            .ensure_valid_access_token(user_id, ConnectedOAuthProvider::Slack)
-            .await
-        {
-            Ok(token) => (token.access_token, None),
-            Err(err) => return map_oauth_error(err),
-        },
+        RequestedScope::Personal => {
+            return JsonResponse::bad_request(
+                "Personal scope requires an explicit OAuth connection",
+            )
+            .into_response();
+        }
     };
 
     if let Some(workspace_id) = workspace_id {
@@ -712,7 +710,6 @@ mod tests {
                     redirect_uri: "http://localhost/asana".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/stripe.rs
+++ b/backend/src/routes/stripe.rs
@@ -1391,7 +1391,6 @@ mod tests {
                     redirect_uri: "https://app.example.com/oauth/asana".into(),
                 },
                 token_encryption_key: vec![0; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/workflows/runs.rs
+++ b/backend/src/routes/workflows/runs.rs
@@ -899,7 +899,6 @@ mod tests {
                     redirect_uri: "https://app.example.com/oauth/asana".into(),
                 },
                 token_encryption_key: vec![0; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1; 32],
             stripe: StripeSettings {

--- a/backend/src/routes/workflows/webhooks.rs
+++ b/backend/src/routes/workflows/webhooks.rs
@@ -709,7 +709,6 @@ mod tests {
                     redirect_uri: "https://app.example.com/oauth/asana".into(),
                 },
                 token_encryption_key: vec![0; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1; 32],
             stripe: StripeSettings {

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -595,7 +595,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             stripe: crate::config::StripeSettings {
                 client_id: "stub".into(),

--- a/backend/src/utils/workflow_connection_metadata.rs
+++ b/backend/src/utils/workflow_connection_metadata.rs
@@ -127,14 +127,6 @@ fn collect_from_object(map: &Map<String, Value>, seen: &mut BTreeSet<ConnectionM
     if let Some(metadata) = resolve_connection_metadata(map, None) {
         seen.insert(metadata);
     }
-
-    let legacy_user = map.contains_key("oauthConnectionId")
-        || map.contains_key("oauthAccountEmail")
-        || map.contains_key("accountEmail");
-
-    if legacy_user {
-        seen.insert(ConnectionMetadata::user());
-    }
 }
 
 fn resolve_connection_metadata(

--- a/backend/src/worker/mod.rs
+++ b/backend/src/worker/mod.rs
@@ -675,7 +675,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {
@@ -916,7 +915,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {
@@ -1115,7 +1113,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {
@@ -1323,7 +1320,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {
@@ -1492,7 +1488,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {
@@ -1647,7 +1642,6 @@ mod tests {
                     redirect_uri: "http://localhost".into(),
                 },
                 token_encryption_key: vec![0u8; 32],
-                require_connection_id: false,
             },
             api_secrets_encryption_key: vec![1u8; 32],
             stripe: StripeSettings {

--- a/backend/test_syntax.rs
+++ b/backend/test_syntax.rs
@@ -1,0 +1,1 @@
+use crate::services::oauth::account_service::OAuthAccountError; fn test() { let token = Ok(()); }

--- a/frontend/src/components/AGENTS.md
+++ b/frontend/src/components/AGENTS.md
@@ -51,6 +51,7 @@
 - Settings > Integrations: mapped providers to dedicated logo components and render the Slack logo inside the 40x40 placeholder while keeping the slot reusable for future provider icons.
 - Slack logo SVG now uses a padded viewBox and full-size scaling so it fits cleanly within the 40x40 header placeholder without crowding the border.
 - Settings > Integrations: support multiple personal/workspace connections per provider, add provider search filtering, surface connection IDs, and keep per-connection actions usable when starting new connection flows.
+- Settings > Integrations: refresh/disconnect actions now require explicit connection IDs, disable controls when an ID is unavailable, and avoid provider-only requests to mirror backend enforcement.
 - Google Sheets flyout picker now sends client/app IDs, scope, and the fetched OAuth token to Drive Picker and blocks missing-config cases so the picker works in the flyout without console errors.
 - Delay and Formatter nodes now mirror other action nodes: canvas cards are minimal and configuration is handled exclusively in the flyout.
 - Slack action channel selection now hides the manual input when an OAuth connection is chosen and loads channels into a dropdown from the backend Slack channels endpoint.

--- a/frontend/tests/lib/oauthApi.test.ts
+++ b/frontend/tests/lib/oauthApi.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { disconnectProvider, refreshProvider } from '@/lib/oauthApi'
+
+const getCsrfToken = vi.hoisted(() => vi.fn().mockResolvedValue('csrf-token'))
+
+vi.mock('@/lib/config', () => ({
+  API_BASE_URL: 'http://api.test'
+}))
+
+vi.mock('@/lib/csrfCache', () => ({
+  getCsrfToken
+}))
+
+describe('oauthApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getCsrfToken.mockResolvedValue('csrf-token')
+    global.fetch = vi.fn()
+  })
+
+  it('throws when connectionId is missing or blank for refresh', async () => {
+    await expect(refreshProvider('google', '   ')).rejects.toThrow(
+      /connectionid is required/i
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('throws when connectionId is missing or blank for disconnect', async () => {
+    await expect(disconnectProvider('google', '')).rejects.toThrow(
+      /connectionid is required/i
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('sends connection_id when refreshing a provider', async () => {
+    const responsePayload = {
+      success: true,
+      requiresReconnect: false,
+      accountEmail: 'owner@example.com',
+      expiresAt: '2025-01-01T00:00:00.000Z',
+      lastRefreshedAt: '2024-12-31T15:30:00.000Z'
+    }
+    ;(global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => responsePayload
+    })
+
+    await refreshProvider('google', 'conn-123')
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = (global.fetch as vi.Mock).mock.calls[0]
+    expect(String(url)).toContain(
+      '/api/oauth/google/refresh?connection_id=conn-123'
+    )
+    expect(init).toMatchObject({
+      method: 'POST',
+      credentials: 'include',
+      headers: expect.objectContaining({ 'x-csrf-token': 'csrf-token' })
+    })
+  })
+
+  it('sends connection_id when disconnecting a provider', async () => {
+    ;(global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    })
+
+    await disconnectProvider('slack', 'conn-456')
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = (global.fetch as vi.Mock).mock.calls[0]
+    expect(String(url)).toContain(
+      '/api/oauth/slack/disconnect?connection_id=conn-456'
+    )
+    expect(init).toMatchObject({
+      method: 'DELETE',
+      credentials: 'include',
+      headers: expect.objectContaining({ 'x-csrf-token': 'csrf-token' })
+    })
+  })
+
+  it('enforces provider type at compile time', () => {
+    type ProviderParam = Parameters<typeof refreshProvider>[0]
+    // @ts-expect-error invalid provider should not compile
+    const invalidProvider: ProviderParam = 'unknown-provider'
+    expect(invalidProvider).toBeDefined()
+  })
+})


### PR DESCRIPTION
Enforce explicit token ID selection inside WorkspaceOAuthService promotion

Send explicit user_oauth_token_id from Integrations tab promotions

Require explicit OAuth connectionId in action connection resolution

Enforce personal connection IDs for OAuth actions

Stop inferring user connections from legacy OAuth fields

build fixes

Refresh OAuth action tests for explicit connection enforcement

test fixes

remove legacy oauth fallback paths

fix: remove remaining personal-scope oauth fallback calls

chore: remove oauth.require_connection_id and legacy oauth fallback plumbing

test fixes/refactors

Enforce connection_id requirement and drop provider fallback on OAuth refresh/disconnect

Require connectionId in OAuth client helpers and Integrations UI

Add backend and frontend coverage for required connection IDs